### PR TITLE
Make reference a string

### DIFF
--- a/PluploadMvc.Sample/Models/SampleForm1Model.cs
+++ b/PluploadMvc.Sample/Models/SampleForm1Model.cs
@@ -8,17 +8,17 @@ namespace XperiCode.PluploadMvc.Sample.Models
     {
         public SampleForm1Model()
         {
-            UploadReference1 = Guid.NewGuid();
-            UploadReference2 = Guid.NewGuid();
+            UploadReference1 = Guid.NewGuid().ToString();
+            UploadReference2 = "12345";
         }
 
         [Display(Name = "Some text")]
         public string Text { get; set; }
 
         [Display(Name = "Some files")]
-        public Guid UploadReference1 { get; set; }
+        public string UploadReference1 { get; set; }
 
         [Display(Name = "Some other files")]
-        public Guid UploadReference2 { get; set; }
+        public string UploadReference2 { get; set; }
     }
 }

--- a/PluploadMvc.Tests/PluploadContextTests.cs
+++ b/PluploadMvc.Tests/PluploadContextTests.cs
@@ -132,5 +132,24 @@ namespace XperiCode.PluploadMvc.Tests
                 // Files could always be in use by virusscanners and what not.. So ignore it.
             }
         }
+
+        [TestMethod(), ExpectedException(typeof(ArgumentException))]
+        public void Should_Throw_ArgumentException_When_Reference_Contains_Invalid_FileName_Chars()
+        {
+            var httpContextMock = new Mock<HttpContextBase>();
+            var httpContext = httpContextMock.Object;
+
+            var pluploadContext = new PluploadContext(httpContext);
+
+            try
+            {
+                pluploadContext.DeleteFiles("dsf:sdf");
+            }
+            catch (ArgumentException ex)
+            {
+                Assert.AreEqual("reference", ex.ParamName);
+                throw;
+            }
+        }
     }
 }

--- a/PluploadMvc.Tests/PluploadContextTests.cs
+++ b/PluploadMvc.Tests/PluploadContextTests.cs
@@ -42,7 +42,7 @@ namespace XperiCode.PluploadMvc.Tests
             {
                 httpPostedFileMock.SetupGet(f => f.InputStream).Returns(stream);
 
-                var reference = Guid.NewGuid();
+                var reference = Guid.NewGuid().ToString();
 
                 using (var pluploadContext = new PluploadContext(httpContextMock.Object))
                 {
@@ -102,8 +102,8 @@ namespace XperiCode.PluploadMvc.Tests
                 httpPostedFile1Mock.SetupGet(f => f.InputStream).Returns(stream1);
                 httpPostedFile2Mock.SetupGet(f => f.InputStream).Returns(stream2);
 
-                var reference1 = Guid.NewGuid();
-                var reference2 = Guid.NewGuid();
+                var reference1 = Guid.NewGuid().ToString();
+                var reference2 = "98w3jf3498sj";
 
                 using (var pluploadContext = new PluploadContext(httpContextMock.Object))
                 {

--- a/PluploadMvc.Tests/PluploadFileCollectionTests.cs
+++ b/PluploadMvc.Tests/PluploadFileCollectionTests.cs
@@ -7,11 +7,12 @@ namespace XperiCode.PluploadMvc.Tests
     public class PluploadFileCollectionTests
     {
         [TestMethod]
-        public void Should_Initialize_Reference_With_Non_Empty_Guid_On_Construction()
+        public void Should_Initialize_Reference_With_Non_Empty_String_On_Construction()
         {
             var collection = new PluploadFileCollection();
 
-            Assert.AreNotEqual(Guid.Empty, collection.Reference);
+            Assert.IsNotNull(collection.Reference);
+            Assert.AreNotEqual(string.Empty, collection.Reference);
         }
     }
 }

--- a/PluploadMvc.Tests/PluploadFileTests.cs
+++ b/PluploadMvc.Tests/PluploadFileTests.cs
@@ -14,7 +14,7 @@ namespace XperiCode.PluploadMvc.Tests
             string tempFileName = "FileName.Extension";
             string tempFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Guid.NewGuid().ToString());
             string tempFileNamePath = Path.Combine(tempFilePath, tempFileName);
-            Guid reference = Guid.NewGuid();
+            string reference = Guid.NewGuid().ToString();
 
             if (!Directory.Exists(tempFilePath))
             {
@@ -62,7 +62,7 @@ namespace XperiCode.PluploadMvc.Tests
         [TestMethod]
         public void Should_Have_Empty_Properties_When_Supplied_Not_Existing_FileNamePath()
         {
-            using (var file = new PluploadFile(string.Concat(@"c:\", Guid.NewGuid(), Guid.NewGuid()), Guid.NewGuid()))
+            using (var file = new PluploadFile(string.Concat(@"c:\", Guid.NewGuid(), Guid.NewGuid()), Guid.NewGuid().ToString()))
             {
                 Assert.IsNull(file.FileName);
                 Assert.IsNull(file.ContentType);
@@ -90,7 +90,7 @@ namespace XperiCode.PluploadMvc.Tests
                 fileStream.Flush();
             }
 
-            using (var file = new PluploadFile(tempFileNamePath, Guid.NewGuid()))
+            using (var file = new PluploadFile(tempFileNamePath, Guid.NewGuid().ToString()))
             {
                 string tempFileName2 = "FileName.Extension";
                 string tempFilePath2 = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Guid.NewGuid().ToString());

--- a/PluploadMvc.Tests/PluploadHandlerTests.cs
+++ b/PluploadMvc.Tests/PluploadHandlerTests.cs
@@ -14,7 +14,7 @@ namespace XperiCode.PluploadMvc.Tests
         [TestMethod()]
         public void ProcessRequest_Should_Save_File()
         {
-            var reference = Guid.NewGuid();
+            var reference = Guid.NewGuid().ToString();
             var pluploadContextMock = new Mock<IPluploadContext>();
             var httpPostedFileMock = new Mock<HttpPostedFileBase>();
             var httpFileCollectionMock = new Mock<HttpFileCollectionBase>();

--- a/PluploadMvc/IPluploadContext.cs
+++ b/PluploadMvc/IPluploadContext.cs
@@ -7,10 +7,10 @@ namespace XperiCode.PluploadMvc
 {
     public interface IPluploadContext
     {
-        void SaveChunk(HttpPostedFileBase file, Guid reference, string fileName, int chunk, int chunks);
-        void SaveFile(HttpPostedFileBase file, Guid reference);
-        IEnumerable<HttpPostedFileBase> GetFiles(Guid reference);
-        void DeleteFiles(Guid reference);
+        void SaveChunk(HttpPostedFileBase file, string reference, string fileName, int chunk, int chunks);
+        void SaveFile(HttpPostedFileBase file, string reference);
+        IEnumerable<HttpPostedFileBase> GetFiles(string reference);
+        void DeleteFiles(string reference);
         void DeleteFiles(PluploadFileCollection collection);
     }
 }

--- a/PluploadMvc/PluploadFile.cs
+++ b/PluploadMvc/PluploadFile.cs
@@ -15,10 +15,12 @@ namespace XperiCode.PluploadMvc
         private readonly FileStream _fileStream;
         private readonly string _contentType;
         private readonly int _contentLength;
-        private readonly Guid _reference;
+        private readonly string _reference;
 
-        public PluploadFile(string fileNamePath, Guid reference)
+        public PluploadFile(string fileNamePath, string reference)
         {
+            PluploadContext.GuardInvalidReference(reference);
+
             if (!File.Exists(fileNamePath))
             {
                 return;
@@ -36,7 +38,7 @@ namespace XperiCode.PluploadMvc
             }
         }
 
-        internal Guid Reference 
+        internal string Reference 
         { 
             get
             {

--- a/PluploadMvc/PluploadFileCollection.cs
+++ b/PluploadMvc/PluploadFileCollection.cs
@@ -7,20 +7,24 @@ namespace XperiCode.PluploadMvc
 {
     public class PluploadFileCollection : ReadOnlyCollection<PluploadFile>
     {
-        public PluploadFileCollection() : this(new List<PluploadFile>(), Guid.NewGuid())
+        public PluploadFileCollection() : this(new List<PluploadFile>(), Guid.NewGuid().ToString())
         {
         }
 
-        public PluploadFileCollection(IList<PluploadFile> list, Guid reference) : base(list)
+        public PluploadFileCollection(string reference) : this(new List<PluploadFile>(), reference)
+        {
+        }
+
+        public PluploadFileCollection(IList<PluploadFile> files, string reference) : base(files)
         {
             this.Reference = reference;
         }
 
-        internal Guid Reference { get; set; }
+        internal string Reference { get; set; }
 
         public override string ToString()
         {
-            return this.Reference.ToString();
+            return this.Reference;
         }
     }
 }

--- a/PluploadMvc/PluploadHandler.cs
+++ b/PluploadMvc/PluploadHandler.cs
@@ -19,12 +19,12 @@ namespace XperiCode.PluploadMvc
 
         public void ProcessRequest(HttpContextBase context)
         {
-            Guid reference;
+            string reference = context.Request.Params["reference"];
 
-            if (!Guid.TryParse(context.Request.Params["reference"], out reference))
+            if (!PluploadContext.ValidateReference(reference))
             {
                 context.Response.StatusCode = 500;
-                context.Response.Write("No reference found in postdata or querystring.");
+                context.Response.Write("No reference found in postdata or querystring, or reference contains invalid filename chars.");
                 return;
             }
 

--- a/PluploadMvc/PluploadModelBinder.cs
+++ b/PluploadMvc/PluploadModelBinder.cs
@@ -9,7 +9,7 @@ namespace XperiCode.PluploadMvc
     {
         public override object BindModel(ControllerContext controllerContext, ModelBindingContext bindingContext)
         {
-            Guid reference = Guid.Parse(bindingContext.ValueProvider.GetValue(bindingContext.ModelName).AttemptedValue);
+            string reference = bindingContext.ValueProvider.GetValue(bindingContext.ModelName).AttemptedValue;
 
             var pluploadContext = controllerContext.HttpContext.GetPluploadContext();
             var files = pluploadContext.GetFiles(reference).Cast<PluploadFile>().ToList();

--- a/PluploadMvc/UrlHelperExtensions.cs
+++ b/PluploadMvc/UrlHelperExtensions.cs
@@ -5,7 +5,7 @@ namespace XperiCode.PluploadMvc
 {
     public static class UrlHelperExtensions
     {
-        public static string PluploadHandler(this UrlHelper urlHelper, Guid reference)
+        public static string PluploadHandler(this UrlHelper urlHelper, string reference)
         {
             return urlHelper.Content(string.Concat("~/Plupload.axd?reference=", reference));
         }


### PR DESCRIPTION
Solves #5. Make reference a string with the limitation that it cannot contain invalid filename chars. This limitation is inevitable due to the current implementation where the reference is used to create a directory to store the files.
